### PR TITLE
More strict check for serialized data. More clear psalm annotations usage

### DIFF
--- a/src/Symfony/SymfonyMessageSerializer.php
+++ b/src/Symfony/SymfonyMessageSerializer.php
@@ -92,7 +92,6 @@ final class SymfonyMessageSerializer implements MessageEncoder, MessageDecoder
     {
         try
         {
-            /** @psalm-var array{message:array<string, string|int|float|null>, namespace:class-string} $data */
             $data = $this->serializer->unserialize($serializedMessage);
 
             self::validateUnserializedData($data);
@@ -162,7 +161,7 @@ final class SymfonyMessageSerializer implements MessageEncoder, MessageDecoder
     }
 
     /**
-     * @psalm-param array{message:array<string, string|int|float|null>, namespace:class-string} $data
+     * @psalm-assert array{message:array<string, mixed>, namespace:class-string} $data
      *
      * @throws \UnexpectedValueException
      */
@@ -178,12 +177,22 @@ final class SymfonyMessageSerializer implements MessageEncoder, MessageDecoder
             );
         }
 
+        if (false === \is_array($data['message']))
+        {
+            throw new \UnexpectedValueException('"message" field from serialized data should be an array');
+        }
+
+        if (false === \is_string($data['namespace']))
+        {
+            throw new \UnexpectedValueException('"namespace" field from serialized data should be a string');
+        }
+
         /**
          * Let's check if the specified class exists.
          *
          * @psalm-suppress DocblockTypeContradiction
          */
-        if ($data['namespace'] === '' || \class_exists((string) $data['namespace']) === false)
+        if ($data['namespace'] === '' || \class_exists($data['namespace']) === false)
         {
             throw new \UnexpectedValueException(
                 \sprintf('Class "%s" not found', $data['namespace'])

--- a/tests/Symfony/SymfonyMessageSerializerTest.php
+++ b/tests/Symfony/SymfonyMessageSerializerTest.php
@@ -77,12 +77,38 @@ final class SymfonyMessageSerializerTest extends TestCase
      *
      * @throws \Throwable
      */
+    public function messageNotArray(): void
+    {
+        $this->expectException(DecodeMessageFailed::class);
+        $this->expectExceptionMessage('"message" field from serialized data should be an array');
+
+        (new SymfonyMessageSerializer())->decode(\json_encode(['message' => 'someValue', 'namespace' => \SomeClass::class]));
+    }
+
+    /**
+     * @test
+     *
+     * @throws \Throwable
+     */
+    public function namespaceNotString(): void
+    {
+        $this->expectException(DecodeMessageFailed::class);
+        $this->expectExceptionMessage('"namespace" field from serialized data should be a string');
+
+        (new SymfonyMessageSerializer())->decode(\json_encode(['message' => [], 'namespace' => new \stdClass]));
+    }
+
+    /**
+     * @test
+     *
+     * @throws \Throwable
+     */
     public function classNotFound(): void
     {
         $this->expectException(DecodeMessageFailed::class);
         $this->expectExceptionMessage('Class "SomeClass" not found');
 
-        (new SymfonyMessageSerializer())->decode(\json_encode(['message' => 'someValue', 'namespace' => \SomeClass::class]));
+        (new SymfonyMessageSerializer())->decode(\json_encode(['message' => [], 'namespace' => \SomeClass::class]));
     }
 
     /**


### PR DESCRIPTION
`message:array<string, mixed>` can be changed to `message:array<string, string|int|float|null>` after https://github.com/vimeo/psalm/issues/2409 resolved in psalm