### PR TITLE
Do not extract types twice, when all inner extractors fails

### DIFF
--- a/src/Symfony/Extractor/FailOverExtractor.php
+++ b/src/Symfony/Extractor/FailOverExtractor.php
@@ -42,7 +42,7 @@ final class FailOverExtractor implements PropertyTypeExtractorInterface
     {
         $cacheKey = \sha1($class . $property);
 
-        if (isset($this->localStorage[$cacheKey]) === false)
+        if (\array_key_exists($cacheKey, $this->localStorage) === false)
         {
             $this->localStorage[$cacheKey] = null;
 


### PR DESCRIPTION
I'm not sure, is it correct, but it's logical